### PR TITLE
fix(core-layout-ui): use logical header padding

### DIFF
--- a/packages/@core/ui-kit/layout-ui/src/components/layout-header.vue
+++ b/packages/@core/ui-kit/layout-ui/src/components/layout-header.vue
@@ -42,6 +42,14 @@ const props = withDefaults(defineProps<Props>(), {});
 
 const slots = useSlots();
 
+const paddingClass = computed(() => {
+  if (typeof document !== 'undefined' && document.dir === 'rtl') {
+    return 'pr-2';
+  }
+
+  return 'pl-2';
+});
+
 const style = computed((): CSSProperties => {
   const { fullWidth, height, show } = props;
   const right = !show || !fullWidth ? undefined : 0;
@@ -62,9 +70,9 @@ const logoStyle = computed((): CSSProperties => {
 
 <template>
   <header
-    :class="theme"
+    :class="[theme, paddingClass]"
     :style="style"
-    class="border-border bg-header top-0 flex w-full flex-[0_0_auto] items-center border-b pl-2 transition-[margin-top] duration-200"
+    class="border-border bg-header top-0 flex w-full flex-[0_0_auto] items-center border-b transition-[margin-top] duration-200"
   >
     <div v-if="slots.logo" :style="logoStyle">
       <slot name="logo"></slot>


### PR DESCRIPTION
## Summary
- switch layout header to logical padding that respects document direction

## Testing
- `pnpm exec eslint packages/@core/ui-kit/layout-ui/src/components/layout-header.vue`
- `node -e "global.document={dir:'ltr'};const cls=(typeof document!=='undefined'&&document.dir==='rtl')?'pr-2':'pl-2';console.log('ltr',cls);document.dir='rtl';const cls2=(typeof document!=='undefined'&&document.dir==='rtl')?'pr-2':'pl-2';console.log('rtl',cls2);"`
- `pnpm test:unit` *(fails: 1 test file, 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6896b84af4a8833195cd21668cf6f179