### PR TITLE
feat(project): add rtl support

### DIFF
--- a/apps/web-ele/src/app.vue
+++ b/apps/web-ele/src/app.vue
@@ -1,5 +1,8 @@
 <script lang="ts" setup>
+import { computed } from 'vue';
+
 import { useElementPlusDesignTokens } from '@vben/hooks';
+import { usePreferences } from '@vben/preferences';
 
 import { ElConfigProvider } from 'element-plus';
 
@@ -8,10 +11,15 @@ import { elementLocale } from '#/locales';
 defineOptions({ name: 'App' });
 
 useElementPlusDesignTokens();
+const { locale } = usePreferences();
+
+const direction = computed(() =>
+  String(locale.value).startsWith('ar') ? 'rtl' : 'ltr',
+);
 </script>
 
 <template>
-  <ElConfigProvider :locale="elementLocale">
+  <ElConfigProvider :locale="elementLocale" :direction="direction">
     <RouterView />
   </ElConfigProvider>
 </template>

--- a/apps/web-naive/src/app.vue
+++ b/apps/web-naive/src/app.vue
@@ -4,7 +4,7 @@ import type { GlobalThemeOverrides } from 'naive-ui';
 import { computed } from 'vue';
 
 import { useNaiveDesignTokens } from '@vben/hooks';
-import { preferences } from '@vben/preferences';
+import { preferences, usePreferences } from '@vben/preferences';
 
 import {
   darkTheme,
@@ -21,15 +21,18 @@ import {
 defineOptions({ name: 'App' });
 
 const { commonTokens } = useNaiveDesignTokens();
+const { locale } = usePreferences();
 
-const tokenLocale = computed(() =>
-  preferences.app.locale === 'zh-CN' ? zhCN : enUS,
-);
+const tokenLocale = computed(() => (locale.value === 'zh-CN' ? zhCN : enUS));
 const tokenDateLocale = computed(() =>
-  preferences.app.locale === 'zh-CN' ? dateZhCN : dateEnUS,
+  locale.value === 'zh-CN' ? dateZhCN : dateEnUS,
 );
 const tokenTheme = computed(() =>
   preferences.theme.mode === 'dark' ? darkTheme : lightTheme,
+);
+
+const direction = computed(() =>
+  String(locale.value).startsWith('ar') ? 'rtl' : 'ltr',
 );
 
 const themeOverrides = computed((): GlobalThemeOverrides => {
@@ -45,6 +48,7 @@ const themeOverrides = computed((): GlobalThemeOverrides => {
     :locale="tokenLocale"
     :theme="tokenTheme"
     :theme-overrides="themeOverrides"
+    :dir="direction"
     class="h-full"
   >
     <NNotificationProvider>


### PR DESCRIPTION
## Summary
- derive app direction from locale in Naive UI app
- inject direction prop into Element Plus config

## Testing
- `pnpm lint apps/web-naive/src/app.vue apps/web-ele/src/app.vue` *(fails: Expected "gap" to come before "align-items" in unrelated file)*
- `pnpm exec eslint apps/web-naive/src/app.vue apps/web-ele/src/app.vue && echo 'ESLint passed'`
- `pnpm test:unit` *(fails: ENETUNREACH, Failed to load script)*

------
https://chatgpt.com/codex/tasks/task_e_6896b848f0208331bd54e6778fc0f598