### PR TITLE
feat: add RTL menu stylesheet

### DIFF
--- a/apps/web-antd/src/design/rtl-menu.css
+++ b/apps/web-antd/src/design/rtl-menu.css
@@ -1,0 +1,51 @@
+/* --- RTL-specific fixes for Vben menu --- */
+html[dir='rtl'] .vben-menu .vben-menu-item {
+  display: flex;
+  align-items: center;
+}
+
+/* 1) Icon at start, with logical spacing */
+html[dir='rtl'] .vben-menu .vben-menu-item__icon {
+  order: 0;
+  margin-inline-end: 8px;
+}
+
+/* 2) Localized title in the flow */
+html[dir='rtl'] .vben-menu .vben-menu-item__label {
+  order: 1;
+}
+
+/* 3) Arrow at the visual end, flipped */
+html[dir='rtl'] .vben-menu .vben-menu-item__arrow {
+  order: 2;
+  margin-inline-start: auto;
+  transform: scaleX(-1);
+}
+
+/* Best-effort neutralizer for inline margin-left that may leak in */
+html[dir='rtl'] .vben-menu [style*='margin-left'] {
+  margin-left: 0 !important;
+}
+
+/* --- If using Ant Design Vue menus somewhere, keep these too --- */
+html[dir='rtl'] .ant-menu .ant-menu-item,
+html[dir='rtl'] .ant-menu .ant-menu-submenu-title {
+  display: flex;
+  align-items: center;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-item-icon {
+  order: 0;
+  margin-inline-end: 8px;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-title-content {
+  order: 1;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-submenu-expand-icon,
+html[dir='rtl'] .ant-menu .ant-menu-submenu-arrow {
+  order: 2;
+  margin-inline-start: auto;
+  transform: scaleX(-1);
+}

--- a/apps/web-antd/src/main.ts
+++ b/apps/web-antd/src/main.ts
@@ -3,6 +3,8 @@ import { unmountGlobalLoading } from '@vben/utils';
 
 import { overridesPreferences } from './preferences';
 
+import './design/rtl-menu.css';
+
 /**
  * 应用初始化完成之后再进行页面加载渲染
  */

--- a/apps/web-ele/src/design/rtl-menu.css
+++ b/apps/web-ele/src/design/rtl-menu.css
@@ -1,0 +1,51 @@
+/* --- RTL-specific fixes for Vben menu --- */
+html[dir='rtl'] .vben-menu .vben-menu-item {
+  display: flex;
+  align-items: center;
+}
+
+/* 1) Icon at start, with logical spacing */
+html[dir='rtl'] .vben-menu .vben-menu-item__icon {
+  order: 0;
+  margin-inline-end: 8px;
+}
+
+/* 2) Localized title in the flow */
+html[dir='rtl'] .vben-menu .vben-menu-item__label {
+  order: 1;
+}
+
+/* 3) Arrow at the visual end, flipped */
+html[dir='rtl'] .vben-menu .vben-menu-item__arrow {
+  order: 2;
+  margin-inline-start: auto;
+  transform: scaleX(-1);
+}
+
+/* Best-effort neutralizer for inline margin-left that may leak in */
+html[dir='rtl'] .vben-menu [style*='margin-left'] {
+  margin-left: 0 !important;
+}
+
+/* --- If using Ant Design Vue menus somewhere, keep these too --- */
+html[dir='rtl'] .ant-menu .ant-menu-item,
+html[dir='rtl'] .ant-menu .ant-menu-submenu-title {
+  display: flex;
+  align-items: center;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-item-icon {
+  order: 0;
+  margin-inline-end: 8px;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-title-content {
+  order: 1;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-submenu-expand-icon,
+html[dir='rtl'] .ant-menu .ant-menu-submenu-arrow {
+  order: 2;
+  margin-inline-start: auto;
+  transform: scaleX(-1);
+}

--- a/apps/web-ele/src/main.ts
+++ b/apps/web-ele/src/main.ts
@@ -3,6 +3,8 @@ import { unmountGlobalLoading } from '@vben/utils';
 
 import { overridesPreferences } from './preferences';
 
+import './design/rtl-menu.css';
+
 /**
  * 应用初始化完成之后再进行页面加载渲染
  */

--- a/apps/web-naive/src/design/rtl-menu.css
+++ b/apps/web-naive/src/design/rtl-menu.css
@@ -1,0 +1,51 @@
+/* --- RTL-specific fixes for Vben menu --- */
+html[dir='rtl'] .vben-menu .vben-menu-item {
+  display: flex;
+  align-items: center;
+}
+
+/* 1) Icon at start, with logical spacing */
+html[dir='rtl'] .vben-menu .vben-menu-item__icon {
+  order: 0;
+  margin-inline-end: 8px;
+}
+
+/* 2) Localized title in the flow */
+html[dir='rtl'] .vben-menu .vben-menu-item__label {
+  order: 1;
+}
+
+/* 3) Arrow at the visual end, flipped */
+html[dir='rtl'] .vben-menu .vben-menu-item__arrow {
+  order: 2;
+  margin-inline-start: auto;
+  transform: scaleX(-1);
+}
+
+/* Best-effort neutralizer for inline margin-left that may leak in */
+html[dir='rtl'] .vben-menu [style*='margin-left'] {
+  margin-left: 0 !important;
+}
+
+/* --- If using Ant Design Vue menus somewhere, keep these too --- */
+html[dir='rtl'] .ant-menu .ant-menu-item,
+html[dir='rtl'] .ant-menu .ant-menu-submenu-title {
+  display: flex;
+  align-items: center;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-item-icon {
+  order: 0;
+  margin-inline-end: 8px;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-title-content {
+  order: 1;
+}
+
+html[dir='rtl'] .ant-menu .ant-menu-submenu-expand-icon,
+html[dir='rtl'] .ant-menu .ant-menu-submenu-arrow {
+  order: 2;
+  margin-inline-start: auto;
+  transform: scaleX(-1);
+}

--- a/apps/web-naive/src/main.ts
+++ b/apps/web-naive/src/main.ts
@@ -3,6 +3,8 @@ import { unmountGlobalLoading } from '@vben/utils';
 
 import { overridesPreferences } from './preferences';
 
+import './design/rtl-menu.css';
+
 /**
  * 应用初始化完成之后再进行页面加载渲染
  */


### PR DESCRIPTION
## Summary
- add RTL menu stylesheet to maintain icon-label-arrow order and flip arrows
- load RTL menu stylesheet in each web app entry

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to load script: https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js)*

------
https://chatgpt.com/codex/tasks/task_e_68972b75714883318046acaec96f27d3