### PR TITLE
chore: change default language to English

### DIFF
--- a/apps/web-antd/index.html
+++ b/apps/web-antd/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />


### PR DESCRIPTION
## Summary
- use `en` as HTML `lang` for web-antd

## Testing
- `pnpm run lint --filter @vben/web-antd` *(fails: vsh: not found)*
- `pnpm test:unit --filter @vben/web-antd` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897351bb63c8331a21c0d6a4ad60426